### PR TITLE
Add missing tempfile dependency

### DIFF
--- a/lib/sf2_to_js/sf2_to_js.rb
+++ b/lib/sf2_to_js/sf2_to_js.rb
@@ -5,6 +5,7 @@ module Sf2ToJs
     require 'midilib'
     require 'fileutils'
     require 'colorize'
+    require 'tempfile'
     include FileUtils
 
     MIDI_LOWEST_NOTE_INDEX = 21


### PR DESCRIPTION
In debian, i needed this line in order to be able to run the script.

I had the error:

> `cmdfile': uninitialized constant Sf2ToJs::Tempfile